### PR TITLE
Stop bundling dependencies in the published package

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ config
 node_modules
 lib
 interfaces
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 npm-debug.log
+dist

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "draftjs-utils",
   "version": "0.7.5",
   "description": "Collection of utility function for use with Draftjs.",
-  "main": "lib/draftjs-utils.js",
+  "main": "dist/index.js",
+  "browser": "lib/draftjs-utils.js",
   "dependencies": {
     "immutable": "^3.x.x"
   },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "draft-js": "^0.10.x"
   },
   "devDependencies": {
+    "babel-cli": "^6.24.1",
     "babel-core": "^6.23.1",
     "babel-eslint": "^7.1.1",
     "babel-loader": "^6.4.0",
@@ -41,9 +42,10 @@
     "url": "https://github.com/jpuri/draftjs-utils.git"
   },
   "scripts": {
-    "clean": "rimraf lib",
+    "clean": "rimraf lib && rimraf dist",
     "build:webpack": "NODE_ENV=production webpack --config config/webpack.prod.config.js",
-    "build": "npm run clean && npm run build:webpack",
+    "build:babel": "babel -d dist js",
+    "build": "npm run clean && npm run build:webpack && npm run build:babel",
     "test": "mocha --compilers js:config/test-compiler.js config/test-setup.js js/**/*Test.js",
     "lint": "eslint js",
     "flow": "flow; test $? -eq 0 -o $? -eq 2",


### PR DESCRIPTION
At the moment all of this package's dependencies are bundled inside the `lib/draftjs-utils.js` file which is shipped on npm.

This is terribly wasteful – the package takes up **± 370kb** in my Webpack bundle because of this. Here is an illustration with other packages next to it:

<img width="729" alt="draftjs-utils size" src="https://user-images.githubusercontent.com/877585/27006235-823af818-4e37-11e7-86a9-c6dbfca9fcfc.png">

The solution is to only compile to ES5 without bundling dependencies. There are many ways to do this, one of the simplest is to use `babel-cli` to run the babel compilation and no bundling.

In this PR I've also moved the other bundle to the `browser` field meant for bundled JS.

Edit: with this work, the package's size shrinks to ± 28kb. Further work could be done to publish this as ES6 modules instead of CommonJS, so we can leverage tree shaking and only include the functions that are used, but I'll leave this for a future PR.