### PR TITLE
Add .npmignore to reduce installed package size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,13 @@
+node_modules
+.DS_Store
+npm-debug.log*
+.npmignore
+.babelrc
+.eslintignore
+.eslintrc
+.flowconfig
+.gitignore
+js
+yarn.lock
+config
+interfaces


### PR DESCRIPTION
Adds a .npmignore so unneeded files aren't in the published package. Here is a diff:

```diff
package.json
- .npmignore
LICENSE
- config/test-compiler.js
- config/test-setup.js
- config/webpack.prod.config.js
- .babelrc
- .eslintrc
- .eslintignore
- interfaces/chai.js
- interfaces/draft-js.js
- interfaces/immutable.js
- interfaces/mocha.js
- interfaces/sinon.js
- js/block.js
- js/common.js
- js/index.js
- js/inline.js
- js/keyPress.js
- js/list.js
- js/__test__/blockTest.js
- js/__test__/commonTest.js
- js/__test__/inlineTest.js
- js/__test__/keyPressTest.js
- js/__test__/listTest.js
- js/__test__/.eslintrc
lib/draftjs-utils.js
- .flowconfig
readme.md
- yarn.lock
```

Package size before/after: 640kb/392kb (52kb with #4).