### PR TITLE
Fix font-size type, string font-size is ignored in react 16 

### DIFF
--- a/js/inline.js
+++ b/js/inline.js
@@ -231,7 +231,7 @@ export function extractInlineStyle(editorState) {
       } else if (style && style.indexOf('bgcolor-') === 0) {
         addToCustomStyleMap('bgcolor', 'backgroundColor', style.substr(8));
       } else if (style && style.indexOf('fontsize-') === 0) {
-        addToCustomStyleMap('fontSize', 'fontSize', style.substr(9));
+        addToCustomStyleMap('fontSize', 'fontSize', +style.substr(9));
       } else if (style && style.indexOf('fontfamily-') === 0) {
         addToCustomStyleMap('fontFamily', 'fontFamily', style.substr(11));
       }


### PR DESCRIPTION
Font size does not work anymore with react 16 when initializing the editor with raw content.
I tracked it down to this:
![screenshot from 2017-10-05 17-43-38](https://user-images.githubusercontent.com/271144/31236664-152083be-a9f5-11e7-8a63-3e7ebfd17c83.png)
As you can see the font-size value is `"96"` and is later ignored for some reason with react 16 (with react 15 it works.)
This PR casts this value to integer and makes it work with react 16:
![screenshot from 2017-10-05 17-48-38](https://user-images.githubusercontent.com/271144/31236802-6dff889a-a9f5-11e7-84f1-c16dc6daf91c.png)

