### PR TITLE
fix getSelectionCustomInlineStyle not actually calling the isCollapse…

### DIFF
--- a/js/inline.js
+++ b/js/inline.js
@@ -220,7 +220,7 @@ export function toggleCustomInlineStyle(
 }
 
 /**
- * 
+ *
  */
 export function extractInlineStyle(editorState) {
   if(editorState) {
@@ -273,7 +273,7 @@ export function getSelectionCustomInlineStyle(
   if (editorState && styles && styles.length > 0) {
     const currentSelection = editorState.getSelection();
     const inlineStyles = {};
-    if (currentSelection.isCollapsed) {
+    if (currentSelection.isCollapsed()) {
       styles.forEach((s) => {
         inlineStyles[s] = getCurrentInlineStyle(editorState, s);
       });


### PR DESCRIPTION
The getSelectionCustomInlineStyle function is just checking that the isCollapsed function exists instead of calling it.

@jpuri  Note that i think you have another issue related to this function in react-draft-wysiwyg here in your Remove control https://github.com/jpuri/react-draft-wysiwyg/blob/master/src/controls/Remove/index.js#L67
getSelectionCustomInlineStyle will only get one instance of the custom inline styles, so, for example, if your selection has multiple colors in it, only one of them will get removed. I'm not sure if that can really be fixed in getSelectionCustomInlineStyle because of the other places it gets used depends on the current behavior. Might want to make a slightly different function to be used in the Remove control that just gives you back an array of all instances of the specified custom inline styles.