### PR TITLE
Add TypeScript definitions

### DIFF
--- a/lib/draftjs-utils.d.ts
+++ b/lib/draftjs-utils.d.ts
@@ -1,0 +1,51 @@
+import {
+  BlockMap,
+  ContentBlock,
+  DraftBlockType,
+  DraftInlineStyle,
+  EditorState,
+  Entity
+} from "draft-js";
+
+declare module "draftjs-utils" {
+  export function getSelectedBlocksMap(state: EditorState): BlockMap;
+  export function getSelectedBlocksList(
+    state: EditorState
+  ): Array<ContentBlock>;
+  export function getSelectedBlock(state: EditorState): ContentBlock;
+  export function getBlockBeforeSelectedBlock(state: EditorState): ContentBlock;
+  export function getAllBlocks(state: EditorState): List<ContentBlock>;
+  export function getSelectedBlocksType(state: EditorState): string | undefined;
+  export function removeSelectedBlocksStyle(state: EditorState): EditorState;
+  export function getSelectionText(state: EditorState): string;
+  export function addLineBreakRemovingSelection(
+    state: EditorState
+  ): EditorState;
+  export function insertNewUnstyledBlock(state: EditorState): EditorState;
+  export function clearEditorContent(state: EditorState): EditorState;
+  export function getSelectionInlineStyle(state: EditorState): DraftInlineStyle;
+  export function setBlockData(state: EditorState, data: any): EditorState;
+  export function getSelectedBlocksMetadata(
+    state: EditorState
+  ): Map<string, any>;
+  export function blockRenderMap(): Map<DraftBlockType, string>;
+  export function getSelectionEntity(state: EditorState): Entity;
+  export function getEntityRange(state: EditorState, entityKey: string): object;
+  export function handleNewLine(state: EditorState, event: Event): EditorState;
+  export function isListBlock(block: ContentBlock): boolean;
+  export function changeDepth(
+    state: EditorState,
+    adjustment: number,
+    maxDepth: number
+  ): EditorState;
+  export function getSelectionCustomInlineStyle(
+    state: EditorState,
+    styles: string[]
+  ): object;
+  export function toggleCustomInlineStyle(
+    state: EditorState,
+    styleType: string,
+    styleValue: string
+  ): EditorState;
+  export function removeAllInlineStyles(state: EditorState): EditorState;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.9.4",
   "description": "Collection of utility function for use with Draftjs.",
   "main": "lib/draftjs-utils.js",
+  "types": "lib/draftjs-utils.d.ts",
   "peerDependencies": {
     "draft-js": "^0.10.x",
     "immutable": "3.x.x || 4.x.x"


### PR DESCRIPTION
Hi @jpuri.

I drafted TypeScript definitions based on the README. I'm not sure whether these are all correct, as I've just stumbled upon your library. Thanks for building it, it's helpful when Draft.js itself is still lacking a lot of selection-related APIs :)

Please take a look when you have a chance. I probably made a few mistakes!

See https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html for reference.

This fixes #15.