### PR TITLE
Update webpack.prod.config.js

### DIFF
--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -9,6 +9,7 @@ module.exports = {
     filename: 'draftjs-utils.js',
     library: 'draftjsUtils',
     libraryTarget: 'umd',
+    globalObject: 'this',
   },
   optimization: {
     minimizer: [new UglifyJsPlugin()],


### PR DESCRIPTION
Make UMD build available on browsers and Node.js.
#30 
Documentation [here](https://webpack.js.org/configuration/output/#outputglobalobject). Discussion [here](https://github.com/webpack/webpack/issues/6642).